### PR TITLE
Convert the payload parameter to a plain-old JS object

### DIFF
--- a/packages/gqlify-firestore/src/index.ts
+++ b/packages/gqlify-firestore/src/index.ts
@@ -66,6 +66,7 @@ export class FirestoreDataSource implements DataSource {
   }
 
   public async create(payload: any): Promise<any> {
+    payload = Object.assign({}, payload);
     const ref = await this.db.collection(this.path).add(payload);
     await ref.update({ id: ref.id });
     const doc = await ref.get();


### PR DESCRIPTION
Convert the `payload` parameter to a plain-old JS object to ensure firestore's Document validation code works.

fixes #29