### PR TITLE
fix thunk typescript in enumField & objectField

### DIFF
--- a/packages/gqlify/src/dataModel/enumField.ts
+++ b/packages/gqlify/src/dataModel/enumField.ts
@@ -3,7 +3,7 @@ import { DataModelType } from './type';
 import EnumType from './namedType/enumType';
 import { isFunction } from 'lodash';
 
-export type EnumTypeOrThunk = () => EnumType | EnumType;
+export type EnumTypeOrThunk = EnumType | (() => EnumType);
 
 export default class EnumField extends Field {
   private enumType: EnumTypeOrThunk;

--- a/packages/gqlify/src/dataModel/objectField.ts
+++ b/packages/gqlify/src/dataModel/objectField.ts
@@ -3,7 +3,7 @@ import { DataModelType } from './type';
 import { capitalize, mapValues, isFunction } from 'lodash';
 import ObjectType from './namedType/objectType';
 
-export type ObjectTypeOrThunk = () => ObjectType | ObjectType;
+export type ObjectTypeOrThunk = ObjectType | (() => ObjectType) ;
 
 export default class ObjectField extends Field {
   private objectType: ObjectTypeOrThunk;


### PR DESCRIPTION
Fix thunk typescript, for example, from `type thunk = () => string | string` to `type thunk = string | (() => string)`.