### PR TITLE
[firestore]: bump @gqlify/server peer dep

### DIFF
--- a/packages/gqlify-firestore/package.json
+++ b/packages/gqlify-firestore/package.json
@@ -35,7 +35,7 @@
     "tslint": "^5.11.0"
   },
   "peerDependencies": {
-    "@gqlify/server": "2.x",
+    "@gqlify/server": "^2.x",
     "firebase-admin": "^6.3.0"
   }
 }


### PR DESCRIPTION
Allow using gqlify/server v3 with gqlify/firestore.

 Currently we get a warning on installation:

```shell
warning " > @gqlify/firestore@3.1.0" has incorrect peer dependency "@gqlify/server@2.x".
warning " > @gqlify/firestore@3.1.0" has incorrect peer dependency "firebase-admin@^6.3.0".
```

Additionally, the `firebase-admin` peer dep throws the above warning even when using `"firebase-admin": "^8.1.0"`, no idea what the fix is here